### PR TITLE
Update junit5 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ mvn eclipse:eclipse
 
 ### テストの実行
 ```bash
-mvn test
+mvn -Dtest=* test
 ```
 
 ## その他

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-TDDBC for Java with JUnit
-====================================
+# TDDBC for Java with JUnit5
 
 これは、TDDBCのJava向けJUnitプロジェクトです。
 
@@ -53,7 +52,7 @@ $ gradle eclipse
 ### テストの実行
 
 ```bash
-$ gradle test
+$ gradle -q junit5Test
 ```
 
 ### gradleによるJava Projectの作成(gradle 1.9以降)

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'org.junit.gen5.gradle'
 
 /* ide */
 apply {
@@ -12,17 +13,29 @@ project.ext {
 }
 version = '1.0-SNAPSHOT'
 
-sourceCompatibility = targetCompatibility = 1.7
+sourceCompatibility = targetCompatibility = 1.8
 
 tasks.withType(AbstractCompile) each { it.options.encoding = 'UTF-8' }
+
+buildscript {
+    repositories {
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    }
+    dependencies {
+        classpath 'org.junit:junit-gradle:5.0.0-SNAPSHOT'
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testCompile 'junit:junit:4.11', { exclude module: 'hamcrest-core' }
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.junit:junit5-api:5.0.0-ALPHA'
+}
+
+junit5 {
+    version '5.0.0-ALPHA'
 }
 
 wrapper {

--- a/pom.xml
+++ b/pom.xml
@@ -12,30 +12,58 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>1.8</java.version>
   </properties>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <groupId>org.junit</groupId>
+      <artifactId>junit5-api</artifactId>
+      <version>5.0.0-ALPHA</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
         <configuration>
           <downloadSources>true</downloadSources>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>surefire-junit5</artifactId>
+            <version>5.0.0-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/tddbc/SampleTest.java
+++ b/src/test/java/tddbc/SampleTest.java
@@ -1,20 +1,21 @@
 package tddbc;
 
-import org.junit.Test;
+import org.junit.gen5.api.Test;
+import org.junit.gen5.api.DisplayName;
+import static org.junit.gen5.api.Assertions.*;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 public class SampleTest {
 
     @Test
+    @DisplayName("should return Hello TDD Boot Camp")
     public void _should_return_Hello_TDD_BootCamp() throws Exception {
         // Setup
         Sample sut = new Sample();
         // Exercise
         String actual = sut.say();
         // Verify
-        assertThat(actual, is("Hello TDD BootCamp!"));
+        assertEquals("Hello TDD BootCamp!", actual);
     }
 
 }


### PR DESCRIPTION
https://github.com/tddbc/java_junit/issues/15 で議題にでていたJUnit5-ALPHAのサンプルを作りました。
- JUnit4からの変更点を明示するために、java_junitのコミットログを引き継いでいます。
- Hamcrestが必須なわけではないので一旦外しました
  - が、需要はあるはずなのでHamcrestなどの外部ライブラリのサンプルは後ほど追加します
